### PR TITLE
 Fix (occasional) race condition between os.remove and os.rename (seen on windows)

### DIFF
--- a/twitter-export-image-fill.py
+++ b/twitter-export-image-fill.py
@@ -39,14 +39,12 @@ else:
 
 # Re-save the JSON data back to the original file.
 def resave_data(data, data_filename, first_data_line, year_str, month_str):
-  # Writing to a separate file so that we can only copy over the
-  # main file when done
-  data_filename_temp = 'data/js/tweets/%s_%s.js.tmp' % (year_str, month_str)
-  with open(data_filename_temp, 'w') as f:
+  # Overwrite the file
+  with open(data_filename, 'r+') as f:
+    f.seek(0)
     f.write(first_data_line)
     json.dump(data, f, indent=2)
-  os.remove(data_filename)
-  os.rename(data_filename_temp, data_filename)
+    f.truncate()
 
 
 # Downloads an avatar image for a tweet.

--- a/twitter-export-image-fill.py
+++ b/twitter-export-image-fill.py
@@ -38,7 +38,7 @@ else:
 # ---------------------------------
 
 # Re-save the JSON data back to the original file.
-def resave_data(data, data_filename, first_data_line, year_str, month_str):
+def resave_data(data, data_filename, first_data_line):
   # Overwrite the file
   with open(data_filename, 'r+') as f:
     f.seek(0)
@@ -187,7 +187,7 @@ for date in index:
 
         # Re-save the JSON file if we grabbed any avatars
         if data_changed or data_changed_retweet:
-          resave_data(data, data_filename, first_data_line, year_str, month_str)
+          resave_data(data, data_filename, first_data_line)
 
       # Don't continue with saving images if a retweet (unless forced to)
       if (not args.include_retweets) and retweeted:
@@ -264,7 +264,7 @@ for date in index:
 
           # Re-save the original JSON file every time, so that the script can continue
           # from this point
-          resave_data(data, data_filename, first_data_line, year_str, month_str)
+          resave_data(data, data_filename, first_data_line)
 
           # Test whether this media is actually a video
           is_video = '/video/' in media['expanded_url']


### PR DESCRIPTION
Changes behaviour in `resave_data` to avoid occasional race condition between calls to `os.remove` and `os.rename` where the removed file would still exist (or still have an active handle) causing the rename operation to fail.

Fixed by overwriting the data in the same file rather than deleting the original and renaming the temporary one.
